### PR TITLE
don't import Amazon::SQS::Simple unconditionally

### DIFF
--- a/squeezy
+++ b/squeezy
@@ -259,7 +259,6 @@ sub aws_recv {
 }
 
 sub send_command_aws {
-   use Amazon::SQS::Simple;
    use Time::HiRes;
 
    # Create an SQS object


### PR DESCRIPTION
Hi Phill @pssc 
Thanks for squeezy - I have been using it for a couple of years.

When I updated recently I got:

```
$ squeezy -print_links
Can't locate Amazon/SQS/Simple.pm in @INC (you may need to install the Amazon::SQS::Simple module) (@INC contains: /etc/perl /usr/local/lib64/perl5/5.24.3/x86_64-linux-thread-multi /usr/local/lib64/perl5/5.24.3 /usr/lib64/perl5/vendor_perl/5.24.3/x86_64-linux-thread-multi /usr/lib64/perl5/vendor_perl/5.24.3 /usr/local/lib64/perl5 /usr/lib64/perl5/vendor_perl/5.24.1 /usr/lib64/perl5/vendor_perl /usr/lib64/perl5/5.24.3/x86_64-linux-thread-multi /usr/lib64/perl5/5.24.3 .) at /usr/bin/squeezy line 262.
BEGIN failed--compilation aborted at /usr/bin/squeezy line 262.
$
```
I don't have any Amazon SQS to try (or an easy way to install the module on gentoo) - so this suggested change is untested with the module installed.

But looking at the code, aws_support checks $INC, and only then eval block imports to allow conditional installation of the module. 

Thanks,

Paul